### PR TITLE
Assign `attributes` and `tags` from `variables.tf` to `label` module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 
 # Module directory
 .terraform/
+
+.idea
+*.iml

--- a/main.tf
+++ b/main.tf
@@ -1,9 +1,12 @@
 # Define composite variables for resources
 module "label" {
-  source    = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.1.0"
-  namespace = "${var.namespace}"
-  name      = "${var.name}"
-  stage     = "${var.stage}"
+  source     = "git::https://github.com/cloudposse/tf_label.git?ref=tags/0.2.0"
+  namespace  = "${var.namespace}"
+  name       = "${var.name}"
+  stage      = "${var.stage}"
+  delimiter  = "${var.delimiter}"
+  attributes = "${var.attributes}"
+  tags       = "${var.tags}"
 }
 
 #
@@ -26,11 +29,7 @@ resource "aws_security_group" "default" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags {
-    Name      = "${module.label.id}"
-    Namespace = "${var.namespace}"
-    Stage     = "${var.stage}"
-  }
+  tags   = "${module.label.tags}"
 }
 
 resource "aws_elasticache_subnet_group" "default" {
@@ -57,7 +56,7 @@ resource "aws_elasticache_replication_group" "default" {
   maintenance_window            = "${var.maintenance_window}"
   notification_topic_arn        = "${var.notification_topic_arn}"
 
-  tags = "${module.label.tags}"
+  tags                          = "${module.label.tags}"
 }
 
 #
@@ -73,14 +72,15 @@ resource "aws_cloudwatch_metric_alarm" "cache_cpu" {
   period              = "300"
   statistic           = "Average"
 
-  threshold = "${var.alarm_cpu_threshold_percent}"
+  threshold           = "${var.alarm_cpu_threshold_percent}"
 
   dimensions {
     CacheClusterId = "${module.label.id}"
   }
 
-  alarm_actions = ["${var.alarm_actions}"]
-  depends_on    = ["aws_elasticache_replication_group.default"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  depends_on          = ["aws_elasticache_replication_group.default"]
+  tags                = "${module.label.tags}"
 }
 
 resource "aws_cloudwatch_metric_alarm" "cache_memory" {
@@ -93,14 +93,15 @@ resource "aws_cloudwatch_metric_alarm" "cache_memory" {
   period              = "60"
   statistic           = "Average"
 
-  threshold = "${var.alarm_memory_threshold_bytes}"
+  threshold           = "${var.alarm_memory_threshold_bytes}"
 
   dimensions {
     CacheClusterId = "${module.label.id}"
   }
 
-  alarm_actions = ["${var.alarm_actions}"]
-  depends_on    = ["aws_elasticache_replication_group.default"]
+  alarm_actions       = ["${var.alarm_actions}"]
+  depends_on          = ["aws_elasticache_replication_group.default"]
+  tags                = "${module.label.tags}"
 }
 
 

--- a/variables.tf
+++ b/variables.tf
@@ -31,11 +31,9 @@ variable "cluster_size" {
   default = "1"
 }
 
-
 variable "port" {
   default = "6379"
 }
-
 
 variable "instance_type" {
   default = "cache.t2.micro"
@@ -80,3 +78,18 @@ variable "availability_zones" {
 }
 
 variable "zone_id" {}
+
+variable "delimiter" {
+  type    = "string"
+  default = "-"
+}
+
+variable "attributes" {
+  type    = "list"
+  default = []
+}
+
+variable "tags" {
+  type    = "map"
+  default = {}
+}


### PR DESCRIPTION
## What

* Assign `attributes` and `tags` from `variables.tf` to internal `label` module


## Why

* The internal `label` module's `attributes` and `tags` should be visible from outside of the top-level module
* If `attributes` and `tags` are not accessible from outside, sometimes it's impossible to create more than one AWS resource from the top-level module
* Without additional `attributes`, it's not possible at all to create `aws_security_group` inside the module since many security groups with the same name `${module.label.id}` are created in the same solution
